### PR TITLE
Retrieves APC prefix from extension config instead of frontend config

### DIFF
--- a/Classes/Controller/Abstract.php
+++ b/Classes/Controller/Abstract.php
@@ -163,10 +163,8 @@ abstract class Tx_Arcavias_Controller_Abstract extends Tx_Extbase_MVC_Controller
 
 			$conf = new MW_Config_Array( array(), $configPaths );
 
-			if( function_exists( 'apc_store' ) === true && $this->_getExtConfig( 'useAPC', false ) == true )
-			{
-				$prefix = ( isset( $this->settings['apc']['prefix'] ) ? $this->settings['apc']['prefix'] : '' );
-				$conf = new MW_Config_Decorator_APC( $conf, $prefix );
+			if( function_exists( 'apc_store' ) === true && $this->_getExtConfig( 'useAPC', false ) == true ) {
+				$conf = new MW_Config_Decorator_APC( $conf, $this->_getExtConfig( 'apcPrefix', 't3:' ) );
 			}
 
 			self::$_config = $conf;

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,4 +1,6 @@
-# cat=tx_arcavias/basic; type=boolean; label=Use APC cache:If Arcavias configuration values should be cached in the APC user cache
-useAPC = 1
 # cat=tx_arcavias/basic; type=boolean; label=Use auto-configuration for RealUrl:If the internal RealUrl auto-configuration for Arcavias plugins should be used
 useRealUrlAutoConfig = 1
+# cat=tx_arcavias/basic; type=boolean; label=Use APC cache:If Arcavias configuration values should be cached in the APC user cache
+useAPC = 1
+# cat=tx_arcavias/basic; type=string; label=APC prefix:The prefix to distinguish configuration values from different instances
+apcPrefix = t3:


### PR DESCRIPTION
The admin interface didn't used the prefix of the frontend
