### PR TITLE
Moves the tt_content configuration inside the page

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -72,11 +72,12 @@ arcaviasJson {
 		select.orderBy = sorting
 		select.languageField = sys_language_uid
 	}
-}
-tt_content {
-	stdWrap {
-		dataWrap = 
-		innerWrap > 
+	
+	tt_content {
+		stdWrap {
+			dataWrap = 
+			innerWrap > 
+		}
 	}
 }
 
@@ -95,10 +96,11 @@ arcaviasPlain {
 		select.orderBy = sorting
 		select.languageField = sys_language_uid
 	}
-}
-tt_content {
-	stdWrap {
-		dataWrap = 
-		innerWrap > 
+	
+	tt_content {
+		stdWrap {
+			dataWrap = 
+			innerWrap > 
+		}
 	}
 }


### PR DESCRIPTION
Right now the tt_content configuration is in global scope, but it's definitely not an good idea to delete tt_content wraps globally ;)

This commit moves the tt_content configuration inside the PAGE object which is IMO the intended behaviour.
